### PR TITLE
V3 lifecycle hook expose error and document required perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ instance profile used by the autoscaling group's launch configuration:
 * ec2:DescribeInstances
 * autoscaling:DescribeAutoScalingGroups
 * autoscaling:DescribeLifecycleHooks
+* autoscaling:CompleteLifecycleAction
 * sqs:DeleteMessage
 * sqs:GetQueueUrl
 * sqs:ReceiveMessage

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ It is also available as a Docker container:
       -e ETCD_BACKUP_BUCKET=my-etcd-backups \
       --rm opsline/etcd-aws
 
+### Policy Permissions
+
+`etcd-aws` requires the following policy permissions be applied to the
+instance profile used by the autoscaling group's launch configuration:
+
+* ec2:DescribeInstances
+* autoscaling:DescribeAutoScalingGroups
+* autoscaling:DescribeLifecycleHooks
+* sqs:DeleteMessage
+* sqs:GetQueueUrl
+* sqs:ReceiveMessage
+
 # CloudFormation
 
 The program `etcd-aws-cfn` generates and deploys a CloudFormation template:

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -56,9 +56,14 @@ func handleLifecycleEvent(m *ec2cluster.LifecycleMessage) (shouldContinue bool, 
 func watchLifecycleEvents(s *ec2cluster.Cluster, queueName string) {
 	localInstance, _ = s.Instance()
 	for {
-		q, _ := LifecycleEventQueueURL(s, queueName)
+		q, err := LifecycleEventQueueURL(s, queueName)
+
+		if err != nil {
+			log.Fatalf("ERROR: LifecycleEventQueueURL: %s", err)
+		}
+
 		log.Printf("SQS queue URL: %s", q)
-		err := s.WatchLifecycleEvents(q, handleLifecycleEvent)
+		err = s.WatchLifecycleEvents(q, handleLifecycleEvent)
 
 		// The lifecycle hook might not exist yet if we're being created
 		// by cloudformation.


### PR DESCRIPTION
Thanks for the work you've done on extending this with etcd3 and TLS support!

While setting this up, I ran into permissions issues with the instance profile I was using. I've exposed the error that is returned when `sqs:GetQueueUrl` permission is not granted, and I've documented the permissions that `etcd-aws` requires.